### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/jenkinsfilerunner-image-sample](https://github.com/jstrachan/jenkinsfilerunner-image-sample.git) |  | []() | 
+[jstrachan/custom-jenkins-sample](https://github.com/jstrachan/custom-jenkins-sample.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jstrachan/jenkinsfilerunner-image-sample](https://github.com/jstrachan/jenkinsfilerunner-image-sample.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/custom-jenkins-sample](https://github.com/jstrachan/custom-jenkins-sample.git) |  | []() | 
+[jstrachan/custom-jenkins-sample2](https://github.com/jstrachan/custom-jenkins-sample2.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: jenkinsfilerunner-image-sample
-  url: https://github.com/jstrachan/jenkinsfilerunner-image-sample.git
+  repo: custom-jenkins-sample
+  url: https://github.com/jstrachan/custom-jenkins-sample.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jstrachan
+  repo: jenkinsfilerunner-image-sample
+  url: https://github.com/jstrachan/jenkinsfilerunner-image-sample.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: custom-jenkins-sample
-  url: https://github.com/jstrachan/custom-jenkins-sample.git
+  repo: custom-jenkins-sample2
+  url: https://github.com/jstrachan/custom-jenkins-sample2.git
   version: ""
   versionURL: ""

--- a/repositories/templates/jstrachan-custom-jenkins-sample-sr.yaml
+++ b/repositories/templates/jstrachan-custom-jenkins-sample-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: custom-jenkins-sample
+  name: jstrachan-custom-jenkins-sample
+spec:
+  description: Imported application for jstrachan/custom-jenkins-sample
+  httpCloneURL: https://github.com/jstrachan/custom-jenkins-sample.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: custom-jenkins-sample
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/custom-jenkins-sample.git

--- a/repositories/templates/jstrachan-custom-jenkins-sample2-sr.yaml
+++ b/repositories/templates/jstrachan-custom-jenkins-sample2-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: custom-jenkins-sample2
+  name: jstrachan-custom-jenkins-sample2
+spec:
+  description: Imported application for jstrachan/custom-jenkins-sample2
+  httpCloneURL: https://github.com/jstrachan/custom-jenkins-sample2.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: custom-jenkins-sample2
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/custom-jenkins-sample2.git

--- a/repositories/templates/jstrachan-jenkinsfilerunner-image-sample-sr.yaml
+++ b/repositories/templates/jstrachan-jenkinsfilerunner-image-sample-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: jenkinsfilerunner-image-sample
+  name: jstrachan-jenkinsfilerunner-image-sample
+spec:
+  description: Imported application for jstrachan/jenkinsfilerunner-image-sample
+  httpCloneURL: https://github.com/jstrachan/jenkinsfilerunner-image-sample.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jenkinsfilerunner-image-sample
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/jenkinsfilerunner-image-sample.git


### PR DESCRIPTION
Update [jstrachan/custom-jenkins-sample2](https://github.com/jstrachan/custom-jenkins-sample2.git) 

Command run was `jwizard import`
<hr />

Update [jstrachan/custom-jenkins-sample](https://github.com/jstrachan/custom-jenkins-sample.git) 

Command run was `jwizard import --jenkinsfilerunner gcr.io/jstrachan-multicluster/jenkinsfilerunner-image-sample:0.0.4`
<hr />

Update [jstrachan/jenkinsfilerunner-image-sample](https://github.com/jstrachan/jenkinsfilerunner-image-sample.git) 

Command run was `jwizard import`